### PR TITLE
Bugfix network not broadcasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,18 @@ Just plug in the SUBZero to a USB port and it will broadcast a WiFi network name
 The easiest way to get up and running with the SUBZero is by grabbing [SUBZero.tar.bz2](https://github.com/Halcy0nic/SUBZero/releases/tag/1v1) image, untaring it, and flashing it onto an SD card.  I recommend using [Etcher](https://www.balena.io/etcher/) for flashing the SD card.  Etcher is easy to use and works on Windows, OSX, and Linux.
 
 #### Installing from source
-To install the SUBZero on your Raspberry Pi Zero W, clone the SUBZero repository from my [GitHub](https://github.com/Halcy0nic/SUBZero) and run the install script.
+
+First you are going to need to flash Raspbian Stretch Lite/Desktop onto an SD card and placed it inside your Raspberry Pi Zero W. Then boot it up and run the following command
+
+```
+sudo raspi-config
+```
+
+Here you will be dropped into the Raspberry Pi configuration menu where you will be able to connect to a wireless network, change your raspberry pi login information, set your country code, etc. After you are done save your changes and `reboot`
+
+After you reboot we will go ahead and get the device ready to download and install the SUBZero code. First run `sudo apt-get install git -y` in order to install git on the device.
+
+Afterwards, tgit so install the SUBZero on your Raspberry Pi Zero W, clone the SUBZero repository from my [GitHub](https://github.com/Halcy0nic/SUBZero) and run the install script.
 
 ``` 
 $ git clone https://github.com/Halcy0nic/SUBZero.git

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+sudo systemctl unmask hostapd
+sudo systemctl enable hostapd
+sudo systemctl start hostapd
 
 sudo apt update && sudo apt upgrade
 sudo apt install -y hostapd dnsmasq

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
-sudo systemctl unmask hostapd
-sudo systemctl enable hostapd
-sudo systemctl start hostapd
-
 sudo apt update && sudo apt upgrade
 sudo apt install -y hostapd dnsmasq
 sudo mkdir -p /var/www/SUBZero/ && sudo cp ./httpsServer.py /var/www/SUBZero && sudo cp wallpaper.jpg /var/www/SUBZero &&  openssl req -new -x509 -keyout server.pem -out server.pem -days 365 -nodes && sudo cp ./server.pem /var/www/SUBZero
@@ -20,5 +16,7 @@ sudo cp ./dhcpcd.conf /etc/
 sudo cp ./dnsmasq.conf /etc/
 sudo cp ./hostapd.conf /etc/hostapd/
 echo "DAEMON_CONF=\"/etc/hostapd/hostapd.conf\"" | sudo tee -a /etc/default/hostapd
+sudo systemctl unmask hostapd
 sudo systemctl enable hostapd
+sudo systemctl start hostapd
 sudo systemctl enable dnsmasq

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,7 @@ sudo cp ./dnsmasq.conf /etc/
 sudo cp ./hostapd.conf /etc/hostapd/
 echo "DAEMON_CONF=\"/etc/hostapd/hostapd.conf\"" | sudo tee -a /etc/default/hostapd
 sudo systemctl unmask hostapd
+sudo ldconfig
 sudo systemctl enable hostapd
 sudo systemctl start hostapd
 sudo systemctl enable dnsmasq


### PR DESCRIPTION
Resolving the Issue of the network interfaces not appearing after the install. It seems to have been an issue with hostapd as referenced [here](https://www.raspberrypi.org/forums/viewtopic.php?t=235598)
The solution is just to unmask hostapd before enabling/starting it.

Fixes #9 and #10 

![image](https://user-images.githubusercontent.com/1075072/54806908-b7615680-4c38-11e9-876c-7b4edbffaf9d.png)
